### PR TITLE
Fix itertools for Python 3 compatibility

### DIFF
--- a/oslom/runner.py
+++ b/oslom/runner.py
@@ -30,11 +30,9 @@ import subprocess
 import logging
 import simplejson as json
 try:
-    # Python 3 compatible
-    from itertools import zip_longest
+    from itertools import zip_longest # Python 3 compatible
 except ImportError:
-    # Python 2 compatible
-    from itertools import izip_longest as zip_longest
+    from itertools import izip_longest as zip_longest # Python 2 compatible
 
 # Defaults
 DEF_MIN_CLUSTER_SIZE = 0

--- a/oslom/runner.py
+++ b/oslom/runner.py
@@ -26,10 +26,15 @@ import re
 import tempfile
 import shutil
 import time
-import subprocess
-import itertools
+import subprocess 
 import logging
 import simplejson as json
+try:
+    # Python 3 compatible
+    from itertools import zip_longest
+except ImportError:
+    # Python 2 compatible
+    from itertools import izip_longest as zip_longest
 
 # Defaults
 DEF_MIN_CLUSTER_SIZE = 0
@@ -120,7 +125,7 @@ class OslomRunner(object):
         clusters = []
         with open(self.get_path(OslomRunner.OUTPUT_FILE), "r") as reader:
             # Read the output file every two lines
-            for line1, line2 in itertools.izip_longest(*[reader] * 2):
+            for line1, line2 in itertools.zip_longest(*[reader] * 2):
                 info = OslomRunner.RE_INFOLINE.match(line1.strip()).groups()
                 nodes = line2.strip().split(" ")
                 if len(nodes) >= min_cluster_size: # Apply min_cluster_size

--- a/oslom/runner.py
+++ b/oslom/runner.py
@@ -123,7 +123,7 @@ class OslomRunner(object):
         clusters = []
         with open(self.get_path(OslomRunner.OUTPUT_FILE), "r") as reader:
             # Read the output file every two lines
-            for line1, line2 in itertools.zip_longest(*[reader] * 2):
+            for line1, line2 in zip_longest(*[reader] * 2):
                 info = OslomRunner.RE_INFOLINE.match(line1.strip()).groups()
                 nodes = line2.strip().split(" ")
                 if len(nodes) >= min_cluster_size: # Apply min_cluster_size

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 NAME = "oslom-runner"
-VERSION = "1.5"
+VERSION = "1.6"
 DESCRIPTION = "An OSLOM (community finding) runner for Python"
 AUTHOR = "Hugo Hromic"
 AUTHOR_EMAIL = "hhromic@gmail.com"


### PR DESCRIPTION
Updated import of "itertools.ziplongest" to accommodate Python 2 (itertools.iziplongest) or Python 3 (itertools.ziplongest). Also updated the version to reflect the change. Completed "run_in_memory" successfully for Python 2/3 on an example network dataset.